### PR TITLE
Report generated for differnetly dated metric files

### DIFF
--- a/exome_report.py
+++ b/exome_report.py
@@ -78,7 +78,6 @@ with open('/gscmnt/gc2783/qc/GMSworkorders/reports/exome_report_template.txt', '
     template = fh.read()
     template_file = Template(template)
 
-
 filename_list = []
 
 for file in metrics_files:
@@ -88,8 +87,9 @@ for file in metrics_files:
 
     #Ini. outgoing files;
     file_name = file.split('.')[0]
-    SSheet_outfile = '{}.cwl.results.{}.tsv'.format(file_name, mm_dd_yy)
-    report_outfile = '{}.cwl.report.{}.txt'.format(file_name, mm_dd_yy)
+    file_date = file.split('.')[-2]
+    SSheet_outfile = '{}.cwl.results.{}.tsv'.format(file_name, file_date)
+    report_outfile = '{}.cwl.report.{}.txt'.format(file_name, file_date)
 
     # Ini. dicts
     results = {}
@@ -213,6 +213,7 @@ for file in metrics_files:
                 seq_in = input('Would you like to add a SEQUENCING_NOTE? y/n: ')
 
                 if seq_in is 'y':
+                    print('Enter "return q return" to exit SEQUENCING_NOTE prompt.')
                     seq_check = True
                     seq_notes = []
                     while True:
@@ -265,7 +266,7 @@ for file in metrics_files:
 
             builds = ','.join(last_succeeded_build_id)
 
-            with open('{}.Data_transfer_help.{}.txt'.format(template_file_dict['WOID'], mm_dd_yy), 'w') as df:
+            with open('{}.Data_transfer_help.{}.txt'.format(template_file_dict['WOID'], file_date), 'w') as df:
                 df.write('Data Transfer Directory ={td}\ncd to parent data dir\ncd to model_data'
                       '\nmkdir data_transfer/{w}\nTransfer Commands:\n\ngenome model cwl-pipeline prep-for-transfer --md5sum'
                       ' --directory={td}  --builds {b}\n\n'


### PR DESCRIPTION
Reports generated will now have the same date as the metric file used to generate it. A new report will be generated for each metric file with differing dates but the same WOID.